### PR TITLE
Modifying Dockerfile to use debian instead of ubuntu

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,4 @@
-#################
-# 42 Valgrind Container
-
-FROM ubuntu:focal
+FROM debian:buster
 
 # Suppress an apt-key warning about standard out not being a terminal. Use in this script is safe.
 ENV APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=DontWarn


### PR DESCRIPTION
I am modifying the Dockerfile to use debian instead of ubuntu, because upon  installing the current ubutu dockerfile on 42 Imacs, students get mainfest for ubuntu focal not found